### PR TITLE
Check session_id for a value before sending to Redis

### DIFF
--- a/dustdevil/session.py
+++ b/dustdevil/session.py
@@ -881,7 +881,7 @@ try:
         @staticmethod
         def load(session_id, connection, **kwargs):
             """Load the stored session."""
-            if connection.exists(session_id) == 1:
+            if session_id and connection.exists(session_id) == 1:
                 try:
                     data = connection.get(session_id)
                     if data:


### PR DESCRIPTION
With the introduction of redis-py v3.0.0, [clients no longer coerce data types](https://github.com/andymccurdy/redis-py#encoding-of-user-input) when interacting with redis instances. This PR fixes an exception thrown when session_id is `None`. 