### PR TITLE
Always take JWT session_id

### DIFF
--- a/dustdevil/handler.py
+++ b/dustdevil/handler.py
@@ -136,6 +136,8 @@ class Handler(object):
         old_session = self.storage_class.load(session_id, self.storage_client, **kw)
 
         if old_session is None or old_session._is_expired():  # create a new session
+            kw['session_id'] = session_id
+            kw['data'] = {}
             new_session = self.storage_class(self.storage_client, **kw)
 
         if old_session is not None:

--- a/dustdevil/session.py
+++ b/dustdevil/session.py
@@ -168,7 +168,7 @@ class BaseSession(collections.MutableMapping):
             self.data = data
             self.duration = duration
             self.expires = expires
-            self.dirty = False
+            self.dirty = True
         else:
             self.session_id = self._generate_session_id()
             self.data = {}
@@ -827,7 +827,7 @@ try:
         def __init__(self, connection, **kwargs):
             super(RedisSession, self).__init__(**kwargs)
             self.connection = connection
-            if 'session_id' not in kwargs:
+            if self.dirty:
                 self.save()
 
         @staticmethod


### PR DESCRIPTION
For new Google Identity Platform tokens. We should always use them as the session ID.