### PR TITLE
Update setup for specific installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 FROM python:3.9-slim
 RUN apt-get update && apt-get install -y git gcc libhdf5-dev locales && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
-COPY requirements.txt ./
 RUN pip install --upgrade pip setuptools \
- && pip install -r requirements.txt \
- && pip install pylint \
- && rm requirements.txt
+ && pip install pylint
 
 ADD . /tmp/dustdevil/
 WORKDIR /tmp/dustdevil/
-ENV PYTHONPATH="$PYTHONPATH:/tmp/dustdevil"
+RUN pip install -e .['test']
 CMD ((git diff --name-only origin/master..$GIT_COMMIT) | grep .py$) | xargs -r -n1 pylint -j 0 -f parseable -r no>pylint.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 RUN apt-get update && apt-get install -y git gcc libhdf5-dev locales && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
 COPY requirements.txt ./
 RUN pip install --upgrade pip setuptools \

--- a/dustdevil/session.py
+++ b/dustdevil/session.py
@@ -123,7 +123,6 @@ import pickle
 import re
 import tempfile
 import time
-import six
 import codecs
 
 __author__ = "Milan Cermak"
@@ -230,9 +229,9 @@ class BaseSession(collections.MutableMapping):
         v = self.duration
         if isinstance(v, datetime.timedelta):
             pass
-        elif isinstance(v, six.integer_types):
+        elif isinstance(v, int):
             self.duration = datetime.timedelta(seconds=v)
-        elif isinstance(v, six.string_types):
+        elif isinstance(v, str):
             self.duration = datetime.timedelta(seconds=int(v))
         else:
             self.duration = datetime.timedelta(seconds=900)  # 15 mins
@@ -256,9 +255,9 @@ class BaseSession(collections.MutableMapping):
         v = self.regeneration_interval
         if isinstance(v, datetime.timedelta):
             pass
-        elif isinstance(v, six.integer_types):
+        elif isinstance(v, int):
             self.regeneration_interval = datetime.timedelta(seconds=v)
-        elif isinstance(v, six.string_types):
+        elif isinstance(v, str):
             self.regeneration_interval = datetime.timedelta(seconds=int(v))
         else:
             self.regeneration_interval = datetime.timedelta(seconds=240)  # 4 mins

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-psycopg2-binary
-pylibmc
-pymongo
-redis
-tornado
-pytest
-pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ mongo_deps = [
 ]
 
 all_deps = tornado_deps + postgres_deps + redis_deps + memcached_deps + mongo_deps
-test_deps = all_deps + [
+# test_deps = all_deps + [ ## only tests for redis so far
+test_deps = redis_deps + [
     'pytest',
     'pytest-cov',
     'pytest-runner',

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,44 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-test_deps = [
+tornado_deps = [
+    'tornado'
+]
+
+postgres_deps = [
+    'psycopg2-binary',
+]
+
+redis_deps = [
+    'redis',
+]
+
+memcached_deps = [
+    'pylibmc'
+]
+
+mongo_deps = [
+    'pymongo'
+]
+
+all_deps = tornado_deps + postgres_deps + redis_deps + memcached_deps + mongo_deps
+test_deps = all_deps + [
     'pytest',
     'pytest-cov',
     'pytest-runner',
 ]
 
 extras = {
-    'test': test_deps
+    'test': test_deps,
+    'tornado': tornado_deps,
+    'postgres': postgres_deps,
+    'redis': redis_deps,
+    'memcached': memcached_deps,
+    'mongo': mongo_deps
 }
 
 setup(
     name='dustdevil',
-    install_requires=[
-        'psycopg2-binary',
-        'pylibmc',
-        'pymongo',
-        'redis',
-        'tornado',
-    ],
     version="0.1.1",
     packages=find_packages(),
     author='Tartan Solutions, Inc',

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,7 +1,6 @@
 # pylint: disable=redefined-outer-name
 import pytest
 from redis.sentinel import Sentinel
-from tornado import web
 from dustdevil import handler
 
 # @pytest.fixture
@@ -29,6 +28,7 @@ TEST_SETTINGS = {
         'UserFullName': 'NAME'
     },
 }
+
 
 @pytest.mark.skip(reason="Currently cannot test this as there is no mymaster redis")
 def test_sentinel(capsys):


### PR DESCRIPTION
* This is so it can be set up to install with whatever requirements are needed based on the how it is specified in requirements.
  e.g. dust_devil['redis'] would include redis
        dust_devil['redis', 'postgres'] would include redis and pyscopg2-binary

 * Remove requirements always required. Dustdevil is set up to use whatever is available/installed ultimately